### PR TITLE
[FEAT] 예약 등록 기능 구현 (옵션, 게시글 추가 예정)

### DIFF
--- a/src/main/java/com/back/domain/reservation/reservation/common/ReservationDeliveryMethod.java
+++ b/src/main/java/com/back/domain/reservation/reservation/common/ReservationDeliveryMethod.java
@@ -1,0 +1,6 @@
+package com.back.domain.reservation.reservation.common;
+
+public enum ReservationDeliveryMethod {
+    OFFLINE,
+    ONLINE
+}

--- a/src/main/java/com/back/domain/reservation/reservation/common/ReservationStatus.java
+++ b/src/main/java/com/back/domain/reservation/reservation/common/ReservationStatus.java
@@ -1,0 +1,31 @@
+package com.back.domain.reservation.reservation.common;
+
+import lombok.Getter;
+
+@Getter
+public enum ReservationStatus {
+    PENDING_APPROVAL("승인 대기"),
+    PENDING_PAYMENT("결제 대기"),
+    PENDING_PICKUP("수령 대기"),
+    SHIPPING("배송 중"),
+    INSPECTING_RENTAL("대여 검수"),
+    RENTING("대여 중"),
+    PENDING_RETURN("반납 대기"),
+    RETURNING("반납 중"),
+    RETURN_COMPLETED("반납 완료"),
+    INSPECTING_RETURN("반납 검수"),
+    PENDING_REFUND("환급 예정"),
+    REFUND_COMPLETED("환급 완료"),
+    LOST_OR_UNRETURNED("미반납/분실"),
+    CLAIMING("청구 진행"),
+    CLAIM_COMPLETED("청구 완료"),
+    REJECTED("승인 거절"),
+    CANCELLED("예약 취소");
+
+    private final String description;
+
+    ReservationStatus(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/back/domain/reservation/reservation/controller/ReservationController.java
+++ b/src/main/java/com/back/domain/reservation/reservation/controller/ReservationController.java
@@ -1,0 +1,38 @@
+package com.back.domain.reservation.reservation.controller;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.member.member.service.MemberService;
+import com.back.domain.reservation.reservation.dto.CreateReservationReqBody;
+import com.back.domain.reservation.reservation.entity.Reservation;
+import com.back.domain.reservation.reservation.service.ReservationService;
+import com.back.global.rsData.RsData;
+import com.back.global.security.SecurityUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/reservations")
+@RequiredArgsConstructor
+public class ReservationController {
+    private final ReservationService reservationService;
+    private final MemberService memberService;
+
+    @Transactional
+    @PostMapping
+    public RsData<Void> createReservation(
+            @Valid @RequestBody CreateReservationReqBody ReqBody,
+            @AuthenticationPrincipal SecurityUser securityUser
+    ) {
+        Member author = memberService.getById(securityUser.getId());
+
+        Reservation reservation = reservationService.create(ReqBody, author);
+
+        return RsData.success("%d번 예약이 생성되었습니다.".formatted(reservation.getId()));
+    }
+}

--- a/src/main/java/com/back/domain/reservation/reservation/dto/CreateReservationReqBody.java
+++ b/src/main/java/com/back/domain/reservation/reservation/dto/CreateReservationReqBody.java
@@ -1,0 +1,28 @@
+package com.back.domain.reservation.reservation.dto;
+
+import com.back.domain.reservation.reservation.common.ReservationDeliveryMethod;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record CreateReservationReqBody(
+        @NotNull
+        ReservationDeliveryMethod receiveMethod,
+        String receiveCarrier,
+        String receiveTrackingNumber,
+        String receiveAddress1,
+        String receiveAddress2,
+        @NotNull
+        ReservationDeliveryMethod returnMethod,
+        String returnCarrier,
+        String returnTrackingNumber,
+        @NotNull
+        @Future // 현재 시간 이후일 것
+        LocalDate reservationStartAt,
+        @NotNull
+        @Future
+        LocalDate reservationEndAt
+        // TODO: 게시글 ID 추가 예정
+) {
+}

--- a/src/main/java/com/back/domain/reservation/reservation/entity/Reservation.java
+++ b/src/main/java/com/back/domain/reservation/reservation/entity/Reservation.java
@@ -1,0 +1,46 @@
+package com.back.domain.reservation.reservation.entity;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.reservation.reservation.common.ReservationDeliveryMethod;
+import com.back.domain.reservation.reservation.common.ReservationStatus;
+import com.back.global.jpa.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Reservation extends BaseEntity {
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReservationStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private ReservationDeliveryMethod receiveMethod;
+    private String receiveCarrier;
+    private String receiveTrackingNumber;
+    private String receiveAddress1;
+    private String receiveAddress2;
+
+    @Enumerated(EnumType.STRING)
+    private ReservationDeliveryMethod returnMethod;
+    private String returnCarrier;
+    private String returnTrackingNumber;
+
+    private String cancelReason;
+    private String rejectReason;
+
+    private LocalDate reservationStartAt;
+    private LocalDate reservationEndAt;
+
+    // TODO: 게시글 연결 필요
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id")
+    private Member author;
+}

--- a/src/main/java/com/back/domain/reservation/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/back/domain/reservation/reservation/repository/ReservationRepository.java
@@ -1,0 +1,21 @@
+package com.back.domain.reservation.reservation.repository;
+
+import com.back.domain.reservation.reservation.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    // TODO: QueryDSL로 변경 예정
+//    @Query("""
+//        SELECT CASE WHEN COUNT(r) > 0 THEN true ELSE false END
+//        FROM Reservation r
+//        WHERE r.post.id = :postId
+//        AND r.status NOT IN ('CANCELLED', 'REJECTED')
+//        AND (r.reservationStartAt < :endAt AND r.reservationEndAt > :startAt)
+//        """)
+//    boolean existsOverlappingReservation(@Param("postId") Long postId,
+//                                         @Param("startAt") LocalDateTime startAt,
+//                                         @Param("endAt") LocalDateTime endAt);
+}

--- a/src/main/java/com/back/domain/reservation/reservation/service/ReservationService.java
+++ b/src/main/java/com/back/domain/reservation/reservation/service/ReservationService.java
@@ -1,0 +1,61 @@
+package com.back.domain.reservation.reservation.service;
+
+import com.back.domain.member.member.entity.Member;
+import com.back.domain.reservation.reservation.common.ReservationStatus;
+import com.back.domain.reservation.reservation.dto.CreateReservationReqBody;
+import com.back.domain.reservation.reservation.entity.Reservation;
+import com.back.domain.reservation.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+    private final ReservationRepository reservationRepository;
+
+    public Reservation create(CreateReservationReqBody reqBody, Member author) {
+        // TODO: 게시글 조회
+        // Post post = postService.getById(reqBody.postId());
+
+        // 1. 기간 중복 체크
+//        validateNoOverlappingReservation(
+//                null, // TODO: post.getId()
+//                reqBody.reservationStartAt(),
+//                reqBody.reservationEndAt()
+//        );
+
+        // 2. 같은 게스트의 중복 예약 체크 (게시글 ID 필요)
+        // validateNoDuplicateReservation(post.getId(), author.getId());
+
+        Reservation reservation = Reservation.builder()
+                .status(ReservationStatus.PENDING_APPROVAL)
+                .receiveMethod(reqBody.receiveMethod())
+                .receiveCarrier(reqBody.receiveCarrier())
+                .receiveTrackingNumber(reqBody.receiveTrackingNumber())
+                .receiveAddress1(reqBody.receiveAddress1())
+                .receiveAddress2(reqBody.receiveAddress2())
+                .returnMethod(reqBody.returnMethod())
+                .returnCarrier(reqBody.returnCarrier())
+                .returnTrackingNumber(reqBody.returnTrackingNumber())
+                .reservationStartAt(reqBody.reservationStartAt())
+                .reservationEndAt(reqBody.reservationEndAt())
+                .author(author)
+                .build();
+        return reservationRepository.save(reservation);
+    }
+
+    // 기간 중복 체크
+//    private void validateNoOverlappingReservation(
+//            Long postId,
+//            LocalDateTime startAt,
+//            LocalDateTime endAt
+//    ) {
+//        boolean hasOverlap = reservationRepository.existsOverlappingReservation(
+//                postId, startAt, endAt
+//        );
+//
+//        if (hasOverlap) {
+//            throw new ServiceException("400-1", "해당 기간에 이미 예약이 있습니다.");
+//        }
+//    }
+}


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- #5 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 예약(Reservation) 엔티티 생성
- 로그인한 유저 정보를 바탕으로 예약 데이터 등록 구현

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 게시글 데이터의 경우 추후 연동시킬 예정입니다.
- ReservationStatus가 매우 복잡한 형태이기에 더 파악하기 쉬운 형태로 수정할 방법을 찾아보고 있습니다.
- 예약 간의 기간 중복 방지 처리 또한 구현 예정입니다.