### PR TITLE
[fix] 회원가입시 변수명 순서 안맞음

### DIFF
--- a/src/main/java/com/back/domain/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/service/MemberService.java
@@ -37,8 +37,8 @@ public class MemberService {
     public Member join(MemberJoinReqBody reqBody, MemberRole role) {
         String password = passwordEncoder.encode(reqBody.password());
         Member member = new Member(reqBody.email(), password, reqBody.name(),
-                reqBody.address1(), reqBody.address2(), reqBody.nickname(),
-                reqBody.phoneNumber(), role);
+                reqBody.phoneNumber(), reqBody.address1(), reqBody.address2(),
+                reqBody.nickname(), role);
         return memberRepository.save(member);
     }
 

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
 
     // 인증 없이 접근 가능한 공개 엔드포인트
     private static final String[] PUBLIC_ENDPOINTS = {
+            "/favicon.ico",
             "/api/v1/members",
             "/api/v1/members/**",           // 회원 인증 (로그인, 회원가입, OAuth2 등)
             "/swagger-ui/**",         // Swagger UI


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #74 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 회원가입 시에 변수명이 순서가 다르게 들어가서 이상한 회원이 만들어짐

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 