### PR TITLE
feat: 게시글 생성 Response DTO 추가

### DIFF
--- a/src/main/java/com/back/domain/post/controller/PostApi.java
+++ b/src/main/java/com/back/domain/post/controller/PostApi.java
@@ -2,6 +2,7 @@ package com.back.domain.post.controller;
 
 import com.back.domain.post.dto.req.PostCreateReqBody;
 import com.back.domain.post.dto.req.PostUpdateReqBody;
+import com.back.domain.post.dto.res.PostCreateResBody;
 import com.back.domain.post.dto.res.PostDetailResBody;
 import com.back.domain.post.dto.res.PostListResBody;
 import com.back.global.rsData.RsData;
@@ -26,7 +27,7 @@ import java.util.List;
 public interface PostApi {
 
     @Operation(summary = "게시글 생성 API", description = "새로운 게시글을 생성합니다.")
-    ResponseEntity<RsData<Long>> createPost(@Valid @RequestBody PostCreateReqBody postCreateReqBody, @AuthenticationPrincipal SecurityUser user);
+    ResponseEntity<RsData<PostCreateResBody>> createPost(@Valid @RequestBody PostCreateReqBody postCreateReqBody, @AuthenticationPrincipal SecurityUser user);
 
     @Operation(summary = "게시글 목록 조회 API", description = "게시글 목록을 조회합니다.")
     ResponseEntity<RsData<PagePayload<PostListResBody>>> getPostList(

--- a/src/main/java/com/back/domain/post/controller/PostController.java
+++ b/src/main/java/com/back/domain/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.back.domain.post.controller;
 
 import com.back.domain.post.dto.req.PostCreateReqBody;
 import com.back.domain.post.dto.req.PostUpdateReqBody;
+import com.back.domain.post.dto.res.PostCreateResBody;
 import com.back.domain.post.dto.res.PostDetailResBody;
 import com.back.domain.post.dto.res.PostListResBody;
 import com.back.domain.post.service.PostService;
@@ -29,12 +30,12 @@ public class PostController implements PostApi {
     private final PostService postService;
 
     @PostMapping
-    public ResponseEntity<RsData<Long>> createPost(
+    public ResponseEntity<RsData<PostCreateResBody>> createPost(
             @Valid @RequestBody PostCreateReqBody reqBody,
             @AuthenticationPrincipal SecurityUser user) {
-        Long postId = this.postService.createPost(reqBody, user.getId());
+        PostCreateResBody body = this.postService.createPost(reqBody, user.getId());
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(new RsData<>(HttpStatus.CREATED, "게시글이 생성되었습니다.", postId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(new RsData<>(HttpStatus.CREATED, "게시글이 생성되었습니다.", body));
     }
 
     @GetMapping
@@ -105,5 +106,4 @@ public class PostController implements PostApi {
 
         return ResponseEntity.ok(new RsData<>(HttpStatus.OK, "게시글이 삭제되었습니다."));
     }
-
 }

--- a/src/main/java/com/back/domain/post/dto/res/PostAuthorDto.java
+++ b/src/main/java/com/back/domain/post/dto/res/PostAuthorDto.java
@@ -3,7 +3,6 @@ package com.back.domain.post.dto.res;
 
 import com.back.domain.member.entity.Member;
 
-
 public record PostAuthorDto(
         Long id,
         String nickname,

--- a/src/main/java/com/back/domain/post/dto/res/PostCreateResBody.java
+++ b/src/main/java/com/back/domain/post/dto/res/PostCreateResBody.java
@@ -1,0 +1,23 @@
+package com.back.domain.post.dto.res;
+
+import com.back.domain.post.entity.Post;
+
+import java.time.LocalDateTime;
+
+public record PostCreateResBody(
+        Long id,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+    public static PostCreateResBody of(Post post) {
+        return new PostCreateResBody(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getCreatedAt(),
+                post.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/back/domain/post/service/PostService.java
+++ b/src/main/java/com/back/domain/post/service/PostService.java
@@ -6,6 +6,7 @@ import com.back.domain.member.entity.Member;
 import com.back.domain.member.repository.MemberRepository;
 import com.back.domain.post.dto.req.PostCreateReqBody;
 import com.back.domain.post.dto.req.PostUpdateReqBody;
+import com.back.domain.post.dto.res.PostCreateResBody;
 import com.back.domain.post.dto.res.PostDetailResBody;
 import com.back.domain.post.dto.res.PostListResBody;
 import com.back.domain.post.entity.*;
@@ -37,7 +38,7 @@ public class PostService {
     private final RegionRepository regionRepository;
     private final CategoryRepository categoryRepository;
 
-    public Long createPost(PostCreateReqBody reqBody, Long memberId) {
+    public PostCreateResBody createPost(PostCreateReqBody reqBody, Long memberId) {
 
         Member author = this.memberRepository.findById(memberId).orElseThrow(() -> new ServiceException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."));
 
@@ -66,7 +67,8 @@ public class PostService {
         post.getPostRegions().addAll(postRegions);
 
         this.postRepository.save(post);
-        return post.getId();
+
+        return PostCreateResBody.of(post);
     }
 
     public PagePayload<PostListResBody> getPostList(Pageable pageable, String keyword, Long categoryId, List<Long> regionIds, Long memberId) {


### PR DESCRIPTION
## 🔖 관련 이슈
- Closes #94

## 🛠️ 작업 내용
- 게시글 **생성 시 응답 DTO(PostCreateResBody)** 추가
- 기존에는 생성된 게시글의 **id만 반환**하던 구조에서,
  이제는 **id, title, content, createdAt, modifiedAt** 를 포함한 객체 반환 방식으로 변경

## 🎨 스크린샷 / 화면 예시 (선택)

### 🕒 수정 전
- 단순히 생성된 게시글의 `id`만 반환

### ✨ 수정 후
- 다음 필드를 포함한 객체 반환  
  - `id`  
  - `title`  
  - `content`  
  - `createdAt`  
  - `modifiedAt`

## 👀 리뷰 요청 사항
-
