### PR TITLE
[FIX] 예약 등록시 같은 게스트의 중복 예약 체크 삭제

### DIFF
--- a/backend/src/main/java/com/back/domain/reservation/service/ReservationService.java
+++ b/backend/src/main/java/com/back/domain/reservation/service/ReservationService.java
@@ -52,9 +52,6 @@ public class ReservationService {
                 null
         );
 
-        // 같은 게스트의 중복 예약 체크 (게시글 ID 필요)
-        validateNoDuplicateReservation(post.getId(), author.getId());
-
         // 자신의 게시글에 대한 예약 금지
         if (post.getAuthor().getId().equals(author.getId())) {
             throw new ServiceException(HttpStatus.BAD_REQUEST, "자신의 게시글에 대한 예약은 불가능합니다.");
@@ -108,14 +105,6 @@ public class ReservationService {
 
         if (hasOverlap) {
             throw new ServiceException(HttpStatus.BAD_REQUEST, "해당 기간에 이미 예약이 있습니다.");
-        }
-    }
-
-    // 같은 게스트의 중복 예약 체크
-    private void validateNoDuplicateReservation(Long postId, Long authorId) {
-        boolean exists = reservationQueryRepository.existsActiveReservation(postId, authorId);
-        if (exists) {
-            throw new ServiceException(HttpStatus.BAD_REQUEST, "이미 해당 게시글에 예약이 존재합니다.");
         }
     }
 


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- #5 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 예약 등록 시 같은 게스트의 중복 등록 방지 기능 제거

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 해당 방지 기능은 기간 중복 체크 만으로 충분하다 판단되어 삭제하였습니다.