### PR TITLE
[FEAT] 게시물의 예약된 날짜 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/back/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/back/domain/post/controller/PostController.java
@@ -23,6 +23,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -67,6 +68,15 @@ public class PostController implements PostApi {
         Long memberId = (user != null) ? user.getId() : null;
 
         PostDetailResBody body = this.postService.getPostById(id, memberId);
+
+        return ResponseEntity.ok(new RsData<>(HttpStatus.OK, "성공", body));
+    }
+
+    @GetMapping("/{id}/reserved-dates")
+    public ResponseEntity<RsData<List<LocalDateTime>>> getReservedDates(
+            @PathVariable Long id
+    ) {
+        List<LocalDateTime> body = this.postService.getReservedDates(id);
 
         return ResponseEntity.ok(new RsData<>(HttpStatus.OK, "성공", body));
     }

--- a/backend/src/main/java/com/back/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/back/domain/post/service/PostService.java
@@ -280,4 +280,7 @@ public class PostService {
         this.postRepository.delete(post);
     }
 
+    public List<LocalDateTime> getReservedDates(Long id) {
+        return postQueryRepository.findReservedDatesFromToday(id);
+    }
 }


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #168 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 엔드포인트 `/api/v1/posts/{id}/reserved-dates`를 통해 특정 게시물의 예약된 날짜 리스트`List<LocalDateTime>` 조회

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 날짜 조회 조건은 **오늘 이후**로 설정하였습니다.
- 해당 API에서 날짜 조회 외의 다른 기능은 없는것으로 보여 DTO없이 `List<LocalDateTime>`으로 반환하였습니다.
  - 추가적으로 보낼 데이터가 있다면 DTO 형태로 수정하겠습니다.
- 기존의 게시글 상세 DTO `PostDetailResBody`에 있던 `reservedDates`도 따로 삭제하지 않았습니다.