### PR TITLE
[Fix] 리프레시 토큰 인증 실패 시 쿠키 무효화

### DIFF
--- a/backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/backend/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -77,9 +77,8 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
                     filterChain.doFilter(request, response);
                     return;
                 } catch (ServiceException e) {
-                    // 회복 실패 → 401
-                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                    return;
+                    cookieHelper.deleteCookie("accessToken");
+                    cookieHelper.deleteCookie("refreshToken");
                 }
             }
 


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #214 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 리프레시 토큰 인증 실패 시 쿠키 무효화

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 테스트 해보니 쿠키는 삭제가 되는데, 프론트 측에서 인증 상태가 초기화가 안되어서 확인이 필요할 것 같습니다.