### PR TITLE
[REFACTOR] 게시글 임베딩 스케줄링 낙관적 락 추가 (버저닝)

### DIFF
--- a/backend/src/main/java/com/back/domain/post/dto/req/PostEmbeddingDto.java
+++ b/backend/src/main/java/com/back/domain/post/dto/req/PostEmbeddingDto.java
@@ -13,7 +13,8 @@ public record PostEmbeddingDto(
         Integer deposit,
         String receiveMethod,
         String returnMethod,
-        List<Long> regionIds
+        List<Long> regionIds,
+        Long embeddingVersion
 ) {
     public static PostEmbeddingDto from(Post post) {
         return new PostEmbeddingDto(
@@ -27,7 +28,8 @@ public record PostEmbeddingDto(
                 post.getReturnMethod().toString(),
                 post.getPostRegions().stream()
                         .map(pr -> pr.getRegion().getId())
-                        .toList()
+                        .toList(),
+                post.getEmbeddingVersion()
         );
     }
 }

--- a/backend/src/main/java/com/back/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/back/domain/post/entity/Post.java
@@ -67,6 +67,9 @@ public class Post extends BaseEntity {
     )
     private Category category;
 
+    @Version
+    private Long embeddingVersion;
+
     public static Post of(
             String title,
             String content,
@@ -92,6 +95,7 @@ public class Post extends BaseEntity {
         post.category = category;
         post.isBanned = false;
         post.embeddingStatus = EmbeddingStatus.WAIT;
+        post.embeddingVersion = 0L;
         return post;
     }
 
@@ -113,6 +117,7 @@ public class Post extends BaseEntity {
         this.returnAddress2 = returnAddress2;
         this.deposit = deposit;
         this.fee = fee;
+        this.embeddingStatus = EmbeddingStatus.WAIT; // 수정 시 임베딩 스케줄러에 대상 포함
     }
 
     public void updateCategory(Category category) {
@@ -143,17 +148,5 @@ public class Post extends BaseEntity {
 
     public void unban() {
         this.isBanned = false;
-    }
-
-    public void pendingEmbedding() {
-        this.embeddingStatus = EmbeddingStatus.PENDING;
-    }
-
-    public void doneEmbedding() {
-        this.embeddingStatus = EmbeddingStatus.DONE;
-    }
-
-    public void waitEmbedding() {
-        this.embeddingStatus = EmbeddingStatus.WAIT;
     }
 }

--- a/backend/src/main/java/com/back/domain/post/service/PostTransactionService.java
+++ b/backend/src/main/java/com/back/domain/post/service/PostTransactionService.java
@@ -1,6 +1,7 @@
 package com.back.domain.post.service;
 
 import com.back.domain.post.common.EmbeddingStatus;
+import com.back.domain.post.dto.req.PostEmbeddingDto;
 import com.back.domain.post.repository.PostQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,36 +15,40 @@ public class PostTransactionService {
     private final PostQueryRepository postQueryRepository;
 
     /**
-     * WAIT -> PENDING으로 벌크 업데이트 (선점)
+     * WAIT -> PENDING으로 벌크 업데이트 (버전 증가 포함)
      */
     @Transactional
     public long updateStatusToPending(List<Long> postIds) {
-        return postQueryRepository.bulkUpdateStatus(
-                postIds,
-                EmbeddingStatus.PENDING,
-                EmbeddingStatus.WAIT
-        );
+        return postQueryRepository.bulkUpdateStatusToPendingWithVersion(postIds);
     }
 
     /**
-     * PENDING -> DONE으로 벌크 업데이트 (완료)
+     * 실제로 선점한 게시글만 검증
+     */
+    @Transactional(readOnly = true)
+    public List<PostEmbeddingDto> verifyAcquiredPosts(List<PostEmbeddingDto> postDtos) {
+        return postQueryRepository.verifyAcquiredPosts(postDtos);
+    }
+
+    /**
+     * PENDING -> DONE으로 업데이트 (개별 처리, 버전 변경 없음)
      */
     @Transactional
-    public void updateStatusToDone(List<Long> postIds) {
+    public void updateStatusToDone(Long postId) {
         postQueryRepository.bulkUpdateStatus(
-                postIds,
+                List.of(postId),
                 EmbeddingStatus.DONE,
                 EmbeddingStatus.PENDING
         );
     }
 
     /**
-     * PENDING -> WAIT으로 벌크 업데이트 (실패 복구)
+     * PENDING -> WAIT으로 복구 (개별 처리, 버전 변경 없음)
      */
     @Transactional
-    public void updateStatusToWait(List<Long> postIds) {
+    public void updateStatusToWait(Long postId) {
         postQueryRepository.bulkUpdateStatus(
-                postIds,
+                List.of(postId),
                 EmbeddingStatus.WAIT,
                 EmbeddingStatus.PENDING
         );


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #243 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
### 게시글 임베딩 스케줄링 작업에 낙관적 락 도입

**변경 사항:**
- `Post` 엔티티에 `embeddingVersion` 필드 추가
- 임베딩 작업 선점 시 버전 검증 로직 구현
- 벌크 업데이트 후 버전 비교를 통해 실제 선점한 게시글만 처리

**동작 방식:**
1. WAIT 상태 게시글 조회 (version=0)
2. 벌크 업데이트로 PENDING 전환 + 버전 증가 (version=1)
3. 버전 검증: 조회 시 버전(0) + 1 = 현재 DB 버전(1) 확인
4. 검증 통과한 게시글만 임베딩 처리

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 벌크 업데이트로 인해 사용하지 않는 entity 내의 `embeddingStatus`변경 메소드를 삭제했습니다.