### PR TITLE
[FEAT] 게시글 수정시 기존 임베딩 데이터 삭제

### DIFF
--- a/backend/src/main/java/com/back/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/back/domain/post/entity/Post.java
@@ -149,4 +149,8 @@ public class Post extends BaseEntity {
     public void unban() {
         this.isBanned = false;
     }
+
+    public void updateEmbeddingStatusWait() {
+        this.embeddingStatus = EmbeddingStatus.WAIT;
+    }
 }

--- a/backend/src/main/java/com/back/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/back/domain/post/service/PostService.java
@@ -286,7 +286,10 @@ public class PostService {
 
 		post.resetPostImages(processPostImage(post, reqBody, images));
 
-		postVectorService.indexPost(post);
+		// 기존 임베딩 데이터 삭제
+		postVectorService.deletePost(postId);
+		// 수정된 게시글은 다시 임베딩 대기 상태로 변경
+		post.updateEmbeddingStatusWait();
 	}
 
 	private List<PostImage> processPostImage(


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #276 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 게시글 수정 시 기존에 vector_store에 저장된 데이터 삭제
- 이후 임베딩 스케줄링 대기 상태`EmbeddingStatus.WAIT`로 전환

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 