### PR TITLE
[FIX] 예약 totalAmount 관련 오류 수정

### DIFF
--- a/backend/src/main/java/com/back/domain/reservation/repository/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/back/domain/reservation/repository/ReservationQueryRepository.java
@@ -119,6 +119,7 @@ public class ReservationQueryRepository extends CustomQuerydslRepositorySupport
                 // Function<JPAQueryFactory, JPAQuery<Reservation>> contentQuery
                 queryFactory -> queryFactory
                         .selectFrom(reservation)
+                        .distinct()
                         .leftJoin(reservation.post, post).fetchJoin()
                         .leftJoin(post.author, member).fetchJoin()
                         .leftJoin(reservation.reservationOptions, reservationOption).fetchJoin()
@@ -151,6 +152,7 @@ public class ReservationQueryRepository extends CustomQuerydslRepositorySupport
                 // Function<JPAQueryFactory, JPAQuery<Reservation>> contentQuery
                 queryFactory -> queryFactory
                         .selectFrom(reservation)
+                        .distinct()
                         .leftJoin(reservation.reservationOptions, reservationOption).fetchJoin()
                         .leftJoin(reservationOption.postOption, postOption).fetchJoin()
                         .where(


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #280

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 예약 목록 페이지 조회 쿼리에 `distinct()`를 추가하여 일대다 fetchJoin 시 발생하는 예약 옵션 중복 조회 문제를 해결
- `findByAuthorWithFetch` 쿼리에서 사용하지 않는 `post.images` 조인문`.leftJoin(post.images, postImage))`을 제거
## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 수정 후 로컬 테스트 결과 이상이 없는 것으로 보입니다.
  - 이후 배포 상태에서 다시 테스트 해봐야 할 것 같습니다.
- 그 외 기타 사항이 있다면 코드 리뷰를 남겨주세요!