### PR TITLE
[FIX] 예약 totalAmount 관련 오류 수정

### DIFF
--- a/backend/src/main/java/com/back/domain/reservation/entity/Reservation.java
+++ b/backend/src/main/java/com/back/domain/reservation/entity/Reservation.java
@@ -9,6 +9,7 @@ import com.back.global.exception.ServiceException;
 import com.back.global.jpa.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.http.HttpStatus;
 
 import java.time.LocalDate;
@@ -54,6 +55,7 @@ public class Reservation extends BaseEntity {
     private Member author;
 
     @OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 100)
     private List<ReservationOption> reservationOptions = new ArrayList<>();
 
     public void addAllOptions(List<ReservationOption> reservationOptions) {

--- a/backend/src/main/java/com/back/domain/reservation/repository/ReservationQueryRepository.java
+++ b/backend/src/main/java/com/back/domain/reservation/repository/ReservationQueryRepository.java
@@ -119,11 +119,8 @@ public class ReservationQueryRepository extends CustomQuerydslRepositorySupport
                 // Function<JPAQueryFactory, JPAQuery<Reservation>> contentQuery
                 queryFactory -> queryFactory
                         .selectFrom(reservation)
-                        .distinct()
                         .leftJoin(reservation.post, post).fetchJoin()
                         .leftJoin(post.author, member).fetchJoin()
-                        .leftJoin(reservation.reservationOptions, reservationOption).fetchJoin()
-                        .leftJoin(reservationOption.postOption, postOption).fetchJoin()
                         .where(
                                 reservation.author.eq(author),
                                 statusEq(status),
@@ -152,9 +149,6 @@ public class ReservationQueryRepository extends CustomQuerydslRepositorySupport
                 // Function<JPAQueryFactory, JPAQuery<Reservation>> contentQuery
                 queryFactory -> queryFactory
                         .selectFrom(reservation)
-                        .distinct()
-                        .leftJoin(reservation.reservationOptions, reservationOption).fetchJoin()
-                        .leftJoin(reservationOption.postOption, postOption).fetchJoin()
                         .where(
                                 reservation.post.eq(post),
                                 statusEq(status)


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #280 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 일대다 관계 (reservationOptions)에 대한 fetchJoin을 제거하고 엔티티에 `@BatchSize`를 적용
  - 예약 옵션 중복 조회 문제를 해결 (Batch Fetching 전략 도입)
- `findByAuthorWithFetch` 쿼리에서 사용하지 않는 `post.images` 조인문`.leftJoin(post.images, postImage))`을 제거

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 