### PR TITLE
[REFACTOR] 예약 등록 시 동시성 관련 문 개선 (비관적 락)

### DIFF
--- a/backend/src/main/java/com/back/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/back/domain/post/repository/PostRepository.java
@@ -1,13 +1,23 @@
 package com.back.domain.post.repository;
 
 import com.back.domain.post.entity.Post;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findByIsBannedFalse(Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Post p WHERE p.id = :postId")
+    Optional<Post> findByIdWithLock(@Param("postId") Long postId);
 }

--- a/backend/src/main/java/com/back/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/back/domain/post/service/PostService.java
@@ -169,6 +169,11 @@ public class PostService {
 		return PostDetailResBody.of(post, isFavorite, images, authorProfileUrl);
 	}
 
+	public Post getByIdWithLock(Long postId) {
+		return this.postRepository.findByIdWithLock(postId)
+				.orElseThrow(() -> new ServiceException(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."));
+	}
+
 	@Transactional(readOnly = true)
 	public PagePayload<PostListResBody> getMyPosts(Long memberId, Pageable pageable) {
 		Page<PostListResBody> result = this.postQueryRepository.findMyPost(memberId, pageable)

--- a/backend/src/main/java/com/back/domain/reservation/service/ReservationService.java
+++ b/backend/src/main/java/com/back/domain/reservation/service/ReservationService.java
@@ -55,7 +55,7 @@ public class ReservationService {
 
     @Transactional
     public ReservationDto create(CreateReservationReqBody reqBody, Member author) {
-        Post post = postService.getById(reqBody.postId());
+        Post post = postService.getByIdWithLock(reqBody.postId());
 
         // 기간 중복 체크
         validateNoOverlappingReservation(


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #290 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
```java
// ReservationService.java
private void validateNoOverlappingReservation(...) {
    boolean hasOverlap = reservationQueryRepository
        .existsOverlappingReservation(postId, start, end, excludeId);
    // Race condition 발생 가능
}

### 해결예시
// 비관적 락 사용
@Lock(LockModeType.PESSIMISTIC_WRITE)
@Query("SELECT p FROM Post p WHERE p.id = :postId")
Optional<Post> findByIdWithLock(@Param("postId") Long postId);
```
- 동시에 여러 사용자가 같은 게시글에 대해 동일한 시간대로 예약을 시도할 경우, 중복 체크를 통과하여 예약이 중복 생성되는 Race Condition 발생
  - 비관적 락(Pessimistic Lock)을 적용하여 예약 생성/수정 시 Post 엔티티에 대한 동시 접근 제어
  - `@Lock(LockModeType.PESSIMISTIC_WRITE)` 사용으로 트랜잭션이 완료될 때까지 다른 트랜잭션의 접근 차단

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 