### PR TITLE
[FIX] 제재 기능 벌크 업데이트 시 EntityManager.clear() 코드 제거

### DIFF
--- a/backend/src/main/java/com/back/domain/member/repository/MemberQueryRepository.java
+++ b/backend/src/main/java/com/back/domain/member/repository/MemberQueryRepository.java
@@ -13,14 +13,14 @@ public class MemberQueryRepository extends CustomQuerydslRepositorySupport {
     public MemberQueryRepository() { super(Member.class); }
 
     public long bulkBanMember(List<Long> memberIds) {
-        long updatedCount = getQueryFactory()
+        if (memberIds == null || memberIds.isEmpty()) {
+            return 0L;
+        }
+
+        return getQueryFactory()
                 .update(member)
                 .set(member.isBanned, true)
                 .where(member.id.in(memberIds))
                 .execute();
-
-        getEntityManager().clear();
-
-        return updatedCount;
     }
 }

--- a/backend/src/main/java/com/back/domain/post/repository/PostQueryRepository.java
+++ b/backend/src/main/java/com/back/domain/post/repository/PostQueryRepository.java
@@ -1,23 +1,5 @@
 package com.back.domain.post.repository;
 
-import static com.back.domain.member.entity.QMember.*;
-import static com.back.domain.post.entity.QPost.*;
-import static com.back.domain.post.entity.QPostRegion.*;
-import static com.back.domain.region.entity.QRegion.*;
-import static com.back.domain.reservation.entity.QReservation.*;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
-
 import com.back.domain.post.common.EmbeddingStatus;
 import com.back.domain.post.dto.req.PostEmbeddingDto;
 import com.back.domain.post.entity.Post;
@@ -26,6 +8,19 @@ import com.back.domain.reservation.entity.Reservation;
 import com.back.global.queryDsl.CustomQuerydslRepositorySupport;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.back.domain.member.entity.QMember.member;
+import static com.back.domain.post.entity.QPost.post;
+import static com.back.domain.post.entity.QPostRegion.postRegion;
+import static com.back.domain.region.entity.QRegion.region;
+import static com.back.domain.reservation.entity.QReservation.reservation;
 
 @Repository
 public class PostQueryRepository extends CustomQuerydslRepositorySupport {
@@ -102,14 +97,14 @@ public class PostQueryRepository extends CustomQuerydslRepositorySupport {
 	 * @return 실제로 변경된 레코드(row) 수
 	 */
 	public long bulkBanPosts(List<Long> postIds) {
-		long updatedCount = getQueryFactory().update(post)
-			.set(post.isBanned, true)
-			.where(post.id.in(postIds))
-			.execute();
+		if (postIds == null || postIds.isEmpty()) {
+			return 0L;
+		}
 
-		getEntityManager().clear();
-
-		return updatedCount;
+		return getQueryFactory().update(post)
+				.set(post.isBanned, true)
+				.where(post.id.in(postIds))
+				.execute();
 	}
 
 	public List<Post> findPostsToEmbedWithDetails(int limit) {
@@ -133,14 +128,11 @@ public class PostQueryRepository extends CustomQuerydslRepositorySupport {
 			return 0;
 		}
 
-		long updatedCount = getQueryFactory().update(post)
+		return getQueryFactory().update(post)
 			.set(post.embeddingStatus, EmbeddingStatus.PENDING)
 			.set(post.embeddingVersion, post.embeddingVersion.add(1))
 			.where(post.id.in(postIds), post.embeddingStatus.eq(EmbeddingStatus.WAIT))
 			.execute();
-
-		getEntityManager().clear();
-		return updatedCount;
 	}
 
 	/**
@@ -175,14 +167,10 @@ public class PostQueryRepository extends CustomQuerydslRepositorySupport {
 			return 0;
 		}
 
-		long updatedCount = getQueryFactory().update(post)
-			.set(post.embeddingStatus, toStatus)
-			.where(post.id.in(postIds), post.embeddingStatus.eq(fromStatus))
-			.execute();
-
-		getEntityManager().clear();
-
-		return updatedCount;
+		return getQueryFactory().update(post)
+				.set(post.embeddingStatus, toStatus)
+				.where(post.id.in(postIds), post.embeddingStatus.eq(fromStatus))
+				.execute();
 	}
 }
 

--- a/backend/src/main/java/com/back/domain/review/repository/ReviewQueryRepository.java
+++ b/backend/src/main/java/com/back/domain/review/repository/ReviewQueryRepository.java
@@ -148,14 +148,14 @@ public class ReviewQueryRepository extends CustomQuerydslRepositorySupport {
     }
 
     public long bulkBanReview(List<Long> reviewIds) {
-        long updatedCount = getQueryFactory()
+        if (reviewIds == null || reviewIds.isEmpty()) {
+            return 0L;
+        }
+
+        return getQueryFactory()
                 .update(review)
                 .set(review.isBanned, true)
                 .where(review.id.in(reviewIds))
                 .execute();
-
-        getEntityManager().clear();
-
-        return updatedCount;
     }
 }


### PR DESCRIPTION
## 🔖 관련 이슈
> (예시) Closes #103
- Closes #356 

## 🛠️ 작업 내용
> 이번 PR에서 어떤 작업을 했는지 간단히 요약하세요
- 기존에 clear()를 사용했던 이유
  - JPA/Querydsl 벌크 업데이트는 영속성 컨텍스트를 무시하고 DB에만 직접 반영하기 때문에
이미 영속성 컨텍스트에 올라와 있던 엔티티와 DB 상태가 불일치(stale) 되는 문제를 방지하려는 의도에서 `clear()`를 사용함
  - 즉, stale 데이터가 후속 로직에서 다시 flush 되어 DB 값을 덮어쓰는 사고를 예방하기 위한 방어적 코드였음

- 하지만 현재 코드 구조에서는 clear()가 오히려 위험하거나, 의미가 없음

  - `Repository` 내부에서 전역 `entityManager.clear()`를 호출하면
같은 트랜잭션에서 관리되던 다른 엔티티까지 모두 detach 되는 부작용이 발생할 수 있음
  - 특히 서비스 레이어에서 해당 메서드를 호출하는 시점에
다른 엔티티를 수정하거나 LAZY 로딩이 발생하면 예기치 않은 오류 가능
  - 반면, auto-ban 로직에서는 `bulk update` 후 엔티티를 다시 조회하거나 수정하지 않기 때문에
stale 문제가 실제로 발생할 가능성이 없음 → `clear()`가 실질적으로 의미가 없어짐

- 수정 내용

  - `PostQueryRepository`, `MemberQueryRepository`, `ReviewQueryRepository` 내
bulk update 메서드에 포함되어 있던 `entityManager.clear()`를 모두 제거함
  - bulk update는 그대로 유지하며, return되는 업데이트된 row 수는 정상적으로 유지
  - null/empty 입력에 대한 방어 로직 추가
  - 부작용 제거로 인해 전체 트랜잭션의 안정성을 높임

## 🎨 스크린샷 / 화면 예시 (선택)
### 🕒 수정 전

-

### ✨ 수정 후

-

## 👀 리뷰 요청 사항 (선택)
> 특별히 리뷰어가 봐줬으면 하는 부분이 있다면 적어주세요
- 